### PR TITLE
deploy sentry through saas file

### DIFF
--- a/sentry.yaml
+++ b/sentry.yaml
@@ -476,9 +476,9 @@ objects:
                   secretKeyRef:
                     name: smtp
                     key: require_tls
-          envFrom:
-          - configMapRef:
-              name: sentry
+              envFrom:
+              - configMapRef:
+                  name: sentry
               - secretRef:
                   name: sentry-github-oauth
               - secretRef:

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -4,6 +4,18 @@ kind: Template
 metadata:
   name: sentry
 objects:
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: ${SERVICE_ACCOUNT}
+- apiVersion: v1
+  data:
+    SENTRY_SINGLE_ORGANIZATION: "${SENTRY_SINGLE_ORGANIZATION}"
+  kind: ConfigMap
+  metadata:
+    labels:
+      service: sentry
+    name: sentry
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -464,9 +476,9 @@ objects:
                   secretKeyRef:
                     name: smtp
                     key: require_tls
-              envFrom:
-              - configMapRef:
-                  name: sentry
+          envFrom:
+          - configMapRef:
+              name: sentry
               - secretRef:
                   name: sentry-github-oauth
               - secretRef:
@@ -536,3 +548,7 @@ parameters:
   value: "sentry"
   deplayName: sentry service account
   description: name of the service account to use when deploying the pod
+- name: SENTRY_SINGLE_ORGANIZATION
+  value: "true"
+  deplayName: sentry single organization
+  description: should sentry be deployed with a single organization configuration


### PR DESCRIPTION
this PR adds the ServiceAccount and ConfigMap to be deployed through the template itself.

these resources will not be deployed currently as they are filtered out, so i'm going to merge this.

cc @rrati 