### PR TITLE
latest clickhouse dev from mmclane/sentry fork

### DIFF
--- a/Makefile.openshiftdev
+++ b/Makefile.openshiftdev
@@ -29,7 +29,7 @@ clickhouse-deploy-lts:
 	 oc process -f clickhouse.yaml -p CLICKHOUSE_IMAGE=quay.io/mmclane/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=latest | oc -n $(SENTRY_NS) create -f -
 
 clickhouse-update-lts:
-	 oc process -f clickhouse.yaml -p CLICKHOUSE_IMAGE=quay.io/mmclane/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=latest | oc -n $(SENTRY_NS) apply -f -
+	 oc process -f clickhouse.yaml -p CLICKHOUSE_IMAGE=quay.io/mmclane/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=7900d7b | oc -n $(SENTRY_NS) apply -f -
 
 clickhouse-update-fili:
 	 oc process -f clickhouse.yaml -p CLICKHOUSE_IMAGE=filimonovq/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=21.1.2.15 | oc -n $(SENTRY_NS) apply -f -

--- a/clickhouse.yaml
+++ b/clickhouse.yaml
@@ -49,10 +49,10 @@ objects:
           resources:
             limits:
               cpu: 1000m
-              memory: 1024Mi
+              memory: 4096Mi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 2048Mi
           volumeMounts:
           - name: clickhouse-config
             mountPath: /etc/clickhouse-server/config.d


### PR DESCRIPTION
* bumped clickhouse memory req/limit
* bumped clickhouse image tag: clears status semaphore on start