### PR TITLE
Version 20.11.1

### DIFF
--- a/Makefile.openshiftdev
+++ b/Makefile.openshiftdev
@@ -40,3 +40,13 @@ clickhouse-clean:
 clickhouse-debug:
 	oc -n $(SENTRY_NS) logs deployment/clickhouse
 	oc -n $(SENTRY_NS) rsh --shell=/bin/bash --request-timeout=10 deployment/clickhouse
+
+everything-init-probably:
+	# oc new-app --image-stream=openshift/postgresql:9.6-el8 -e POSTGRESQL_USER=sentry -e POSTGRESQL_PASSWORD=secret POSTGRESQL_ADMIN_PASSWORD=admin POSTGRESQL_DATABASE=sentry
+	oc process --local -f test/deploy/sentry-deps.yaml -p SENTRY_SECRET_KEY="$SENTRY_KEY" | oc create -f -
+	oc process --local -f clickhouse.yaml -p CLICKHOUSE_IMAGE=quay.io/mmclane/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=latest | oc create -f -
+	oc process --local -f sentry-init.yaml -p IMAGE=quay.io/rrati/sentry -p IMAGE_TAG=test -p SNUBA_IMAGE=quay.io/rrati/snuba -p SNUBA_IMAGE_TAG=test | oc create -f -
+	oc process --local -f sentry-init.yaml -p IMAGE=quay.io/rrati/sentry -p IMAGE_TAG=test -p SNUBA_IMAGE=quay.io/rrati/snuba -p SNUBA_IMAGE_TAG=test -p SYMBOLICATOR_IMAGE=quay.io/rrati/symbolicator SYMBOLICATOR_IMAGE_TAG=test RELAY_IMAGE=quay.io/rrati/relay RELAY_IMAGE_TAG=test
+
+everything-replace-maybe:
+	oc process -f sentry.yaml -p IMAGE=quay.io/rrati/sentry -p IMAGE_TAG=test -p SNUBA_IMAGE=quay.io/rrati/snuba -p SNUBA_IMAGE_TAG=test -p SYMBOLICATOR_IMAGE=quay.io/rrati/symbolicator -p SYMBOLICATOR_IMAGE_TAG=test -p RELAY_IMAGE=quay.io/rrati/relay -p RELAY_IMAGE_TAG=test | oc replace -f -

--- a/Makefile.openshiftdev
+++ b/Makefile.openshiftdev
@@ -42,7 +42,7 @@ clickhouse-debug:
 	oc -n $(SENTRY_NS) rsh --shell=/bin/bash --request-timeout=10 deployment/clickhouse
 
 everything-init-probably:
-	# oc new-app --image-stream=openshift/postgresql:9.6-el8 -e POSTGRESQL_USER=sentry -e POSTGRESQL_PASSWORD=secret POSTGRESQL_ADMIN_PASSWORD=admin POSTGRESQL_DATABASE=sentry
+	oc new-app --image-stream=openshift/postgresql:9.6-el8 -e POSTGRESQL_USER=sentry -e POSTGRESQL_PASSWORD=XXchangeme POSTGRESQL_ADMIN_PASSWORD=XXchangetoo POSTGRESQL_DATABASE=sentry
 	oc process --local -f test/deploy/sentry-deps.yaml -p SENTRY_SECRET_KEY="$SENTRY_KEY" | oc create -f -
 	oc process --local -f clickhouse.yaml -p CLICKHOUSE_IMAGE=quay.io/mmclane/clickhouse-server -p CLICKHOUSE_IMAGE_TAG=latest | oc create -f -
 	oc process --local -f sentry-init.yaml -p IMAGE=quay.io/rrati/sentry -p IMAGE_TAG=test -p SNUBA_IMAGE=quay.io/rrati/snuba -p SNUBA_IMAGE_TAG=test | oc create -f -

--- a/clickhouse.yaml
+++ b/clickhouse.yaml
@@ -46,7 +46,7 @@ objects:
           resources:
             limits:
               cpu: 1000m
-              memory: 8192Mi
+              memory: 8123Mi
             requests:
               cpu: 100m
               memory: 4096Mi
@@ -82,7 +82,23 @@ objects:
     ports:
     - port: ${{CLICKHOUSE_SERVICE_PORT}}
       protocol: TCP
-      targetPort: 9000
+      targetPort: ${{CLICKHOUSE_SERVICE_PORT}}
+    selector:
+      sentry-task: clickhouse
+    sessionAffinity: None
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      sentry-component: snuba
+      service: sentry
+    name: ${CLICKHOUSE_HTTP_SERVICE}
+  spec:
+    type: ClusterIP
+    ports:
+    - port: ${{CLICKHOUSE_HTTP_SERVICE_PORT}}
+      protocol: TCP
+      targetPort: ${{CLICKHOUSE_HTTP_SERVICE_PORT}}
     selector:
       sentry-task: clickhouse
     sessionAffinity: None
@@ -126,10 +142,18 @@ parameters:
   value: clickhouse
   displayName: clickhouse service name
   description: name of the clickhouse service
+- name: CLICKHOUSE_HTTP_SERVICE
+  value: clickhouse-http
+  displayName: clickhouse http service name
+  description: name of the clickhouse http service
 - name: CLICKHOUSE_SERVICE_PORT
   value: "9000"
   displayName: clickhouse service port
   description: port the clickhouse service listens on for connections
+- name: CLICKHOUSE_HTTP_SERVICE_PORT
+  value: "8123"
+  displayName: clickhouse http service port
+  description: port the clickhouse http service listens on for connections
 - name: CLICKHOUSE_CONFIG_CONFIGMAP
   value: clickhouse
   displayName: clickhouse config map name

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -1503,9 +1503,11 @@ objects:
           - name: SNUBA_SETTINGS
             value: docker
           - name: CLICKHOUSE_HOST
-            value: ${CLICKHOUSE_SERVICE} 
+            value: ${CLICKHOUSE_HTTP_SERVICE} 
           - name: CLICKHOUSE_PORT
             value: ${CLICKHOUSE_SERVICE_PORT}
+          - name: CLICKHOUSE_HTTP_PORT
+            value: ${CLICKHOUSE_HTTP_SERVICE_PORT}
           - name: DEFAULT_BROKERS
             valueFrom:
               secretKeyRef:
@@ -1577,11 +1579,9 @@ objects:
           - name: SNUBA_SETTINGS
             value: docker
           - name: CLICKHOUSE_HOST
-            value: ${CLICKHOUSE_SERVICE} 
+            value: ${CLICKHOUSE_HTTP_SERVICE} 
           - name: CLICKHOUSE_PORT
             value: ${CLICKHOUSE_SERVICE_PORT}
-          - name: CLICKHOUSE_HTTP_HOST
-            value: ${CLICKHOUSE_HTTP_SERVICE} 
           - name: CLICKHOUSE_HTTP_PORT
             value: ${CLICKHOUSE_HTTP_SERVICE_PORT}
           - name: DEFAULT_BROKERS
@@ -1731,9 +1731,11 @@ objects:
           - name: SNUBA_SETTINGS
             value: docker
           - name: CLICKHOUSE_HOST
-            value: ${CLICKHOUSE_SERVICE} 
+            value: ${CLICKHOUSE_HTTP_SERVICE} 
           - name: CLICKHOUSE_PORT
             value: ${CLICKHOUSE_SERVICE_PORT}
+          - name: CLICKHOUSE_HTTP_PORT
+            value: ${CLICKHOUSE_HTTP_SERVICE_PORT}
           - name: DEFAULT_BROKERS
             valueFrom:
               secretKeyRef:

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -38,6 +38,8 @@ objects:
           - run
           - cron
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -160,6 +162,8 @@ objects:
           - run
           - web
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -285,6 +289,8 @@ objects:
           - run
           - worker
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -410,6 +416,10 @@ objects:
           - ingest-consumer
           - --all-consumer-types
           env:
+          - name: SENTRY_KAFKA_HOSTS
+            value: sentry-kafka:9092
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -533,6 +543,8 @@ objects:
           - post-process-forwarder
           - --commit-batch-size=1
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -657,6 +669,8 @@ objects:
           - --commit-batch-size=1 
           - --topic=events-subscription-results
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -781,6 +795,8 @@ objects:
           - --commit-batch-size=1 
           - --topic=transactions-subscription-results
           env:
+          - name: SENTRY_RELAY_PUBLIC_KEYS
+            value: ${SENTRY_RELAY_PUBLIC_KEYS}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -1054,6 +1070,12 @@ objects:
           - -c
           - /etc/relay
           env:
+          - name: RELAY_ID
+            value: ${RELAY_ID}
+          - name: RELAY_PUBLIC_KEY
+            value: ${RELAY_PUBLIC_KEY}
+          - name: RELAY_SECRET_KEY
+            value: ${RELAY_SECRET_KEY}
           - name: SENTRY_POSTGRES_HOST
             valueFrom:
               secretKeyRef:
@@ -1139,9 +1161,6 @@ objects:
           - name: relay-config
             mountPath: /etc/relay/config.yml
             subPath: config.yml
-          - name: relay-credentials
-            mountPath: /etc/relay/credentials.json
-            subPath: credentials.json
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         volumes:
@@ -1151,12 +1170,6 @@ objects:
             items:
             - key: config.yml
               path: config.yml
-        - name: relay-credentials
-          secret:
-            secretName: ${RELAY_CREDENTIALS_SECRET}
-            items:
-            - key: credentials.json
-              path: credentials.json
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -1567,6 +1580,10 @@ objects:
             value: ${CLICKHOUSE_SERVICE} 
           - name: CLICKHOUSE_PORT
             value: ${CLICKHOUSE_SERVICE_PORT}
+          - name: CLICKHOUSE_HTTP_HOST
+            value: ${CLICKHOUSE_HTTP_SERVICE} 
+          - name: CLICKHOUSE_HTTP_PORT
+            value: ${CLICKHOUSE_HTTP_SERVICE_PORT}
           - name: DEFAULT_BROKERS
             valueFrom:
               secretKeyRef:
@@ -2085,22 +2102,18 @@ parameters:
   value: "9092"
   displayName: kafka port
   description: port number kafka listens on for client connections
-- name: RELAY_CREDENTIALS_SECRET
-  value: relay
-  displayName: relay credentials file
-  description: name of the secret containing the relay credentials file
-- name: RELAY_CONFIG_CONFIGMAP
-  value: relay-config
-  displayName: relay config file
-  description: name of the config map containing the relay config file
 - name: RELAY_SERVICE
-  value: relay
+  value: sentry-relay
   displayName: sentry relay service name
   description: name of the sentry relay service
 - name: RELAY_SERVICE_PORT
   value: "3000"
   displayName: sentry relay service port
   description: port the sentry relay service listens on for connections
+- name: RELAY_CONFIG_CONFIGMAP
+  value: relay-config
+  displayName: relay config file
+  description: name of the config map containing the relay config file
 - name: NGINX_IMAGE
   value: quay.io/app-sre/nginx-gate
   displayName: nginx image
@@ -2129,10 +2142,18 @@ parameters:
   value: clickhouse
   displayName: clickhouse service name
   description: name of the clickhouse service
+- name: CLICKHOUSE_HTTP_SERVICE
+  value: clickhouse-http
+  displayName: clickhouse http service name
+  description: name of the clickhouse http service
 - name: CLICKHOUSE_SERVICE_PORT
   value: "9000"
-  displayName: clickhouse service port
+  displayName: clickhouse tcp service port
   description: port the clickhouse service listens on for connections
+- name: CLICKHOUSE_HTTP_SERVICE_PORT
+  value: "8123"
+  displayName: clickhouse http service port
+  description: port the clickhouse service listens on for http connections
 - name: CLICKHOUSE_CONFIG_CONFIGMAP
   value: clickhouse
   displayName: clickhouse config map name
@@ -2177,19 +2198,15 @@ parameters:
   value: "6379"
   displayName: redis port
   description: port number redis listens on for client connections
-- name: SENTRY_SERVICE
-  value: sentry-web
-  displayName: sentry web service name
-  description: name of the sentry web service
-- name: SENTRY_SERVICE_PORT
-  value: "9000"
-  displayName: sentry web service port
-  description: port the sentry web service listens on for connections
-- name: RELAY_SERVICE
-  value: sentry-relay
-  displayName: sentry relay service name
-  description: name of the sentry relay service
-- name: RELAY_SERVICE_PORT
-  value: "3000"
-  displayName: sentry relay service port
-  description: port the sentry relay service listens on for connections
+- name: SENTRY_RELAY_PUBLIC_KEYS
+  value: 2secure4u,change-me-public-key
+  displayName: Sentry Relay Publc Keys
+- name: RELAY_PUBLIC_KEY
+  value: change-me-public-key
+  displayName: Sentry Relay Public Key
+- name: RELAY_SECRET_KEY
+  value: change-me-secret-key
+  displayName: Sentry Relay Secret Key
+- name: RELAY_ID
+  value: nnrelay-id
+  displayName: Secret Relay ID


### PR DESCRIPTION
latest dev updates.. builds/runs.. now with way more env vars.

one thing missing: need to update sentry.conf.py to accept the kafka servicename as an env var.  for now i manually created a service called "kafka" to mirror sentry-kafka, to fast-forward to testing the rest..  phew.

build cmd:
oc process -f sentry.yaml -p IMAGE=quay.io/rrati/sentry -p IMAGE_TAG=test -p SNUBA_IMAGE=quay.io/rrati/snuba -p SNUBA_IMAGE_TAG=test -p SYMBOLICATOR_IMAGE=quay.io/rrati/symbolicator -p SYMBOLICATOR_IMAGE_TAG=test -p RELAY_IMAGE=quay.io/rrati/relay -p RELAY_IMAGE_TAG=test -p RELAY_SECRET_KEY=YYY -p RELAY_PUBLIC_KEY=XXX -p RELAY_ID=ZZZZ -p SENTRY_RELAY_PUBLIC_KEYS=aaa,XXX | oc replace -f -
