### PR TITLE
added probes for sentry-worker and sentry-web

### DIFF
--- a/sentry.yaml
+++ b/sentry.yaml
@@ -415,13 +415,18 @@ objects:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           livenessProbe:
-            periodSeconds: 60
+            periodSeconds: 90
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+            successThreshold: 1
+            failureThreshold: 3
             exec:
               command:
-                - sentry
-                - exec
-                - -c
-                - 'import celery, os; print(celery.task.control.inspect().ping().get("celery@{}".format(os.environ["HOSTNAME"]))["ok"])'
+                - "/usr/bin/sentry"
+                - "exec"
+                - "-c"
+                - "'import celery, os; print(celery.task.control.inspect().ping().get(\"celery@{}\".format(os.environ[\"HOSTNAME\"]))[\"ok\"])'"
+                - 2>/dev/null
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -193,7 +193,7 @@ objects:
       service: sentry
     name: sentry-web
   spec:
-    replicas: ${REPLICAS_WEB}
+    replicas: ${{REPLICAS_WEB}}
     selector:
       matchLabels:
         sentry-component: sentry-web
@@ -321,7 +321,7 @@ objects:
       service: sentry
     name: sentry-worker
   spec:
-    replicas: ${REPLICAS_WORKER}
+    replicas: ${{REPLICAS_WORKER}}
     selector:
       matchLabels:
         sentry-component: sentry-worker

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -293,20 +293,20 @@ objects:
               path: /_health/
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 5
           readinessProbe:
             failureThreshold: 10
             httpGet:
               path: /_health/
               port: 9000
               scheme: HTTP
-            initialDelaySeconds: 10
+            initialDelaySeconds: 20
             periodSeconds: 10
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 5
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler

--- a/sentry.yaml
+++ b/sentry.yaml
@@ -193,7 +193,7 @@ objects:
       service: sentry
     name: sentry-web
   spec:
-    replicas: 2
+    replicas: ${REPLICAS_WEB}
     selector:
       matchLabels:
         sentry-component: sentry-web
@@ -287,6 +287,26 @@ objects:
               memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /_health/
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /_health/
+              port: 9000
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 2
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -301,7 +321,7 @@ objects:
       service: sentry
     name: sentry-worker
   spec:
-    replicas: 1
+    replicas: ${REPLICAS_WORKER}
     selector:
       matchLabels:
         sentry-component: sentry-worker
@@ -394,6 +414,14 @@ objects:
               memory: 512Mi
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+          livenessProbe:
+            periodSeconds: 60
+            exec:
+              command:
+                - sentry
+                - exec
+                - -c
+                - 'import celery, os; print(celery.task.control.inspect().ping().get("celery@{}".format(os.environ["HOSTNAME"]))["ok"])'
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         schedulerName: default-scheduler
@@ -552,5 +580,13 @@ parameters:
   description: name of the service account to use when deploying the pod
 - name: SENTRY_SINGLE_ORGANIZATION
   value: "true"
-  deplayName: sentry single organization
+  displayName: sentry single organization
   description: should sentry be deployed with a single organization configuration
+- name: REPLICAS_WORKER
+  value: "3"
+  displayName: sentry worker replicas
+  description: number of sentry worker replicas to start
+- name: REPLICAS_WEB
+  value: "5"
+  displayName: sentry web replicas
+  description: number of sentry web replicas to start


### PR DESCRIPTION
this will allow sentry-web and sentry-worker to validate they are healthy and if not, will eventually restart/crash gracefully.

tested this by turning off the rds database backing sentry in stage.. then turning it back on, and watched sentry fully recover on its own; verified that after recovery sentry can continue processing messages with zero human interaction required.